### PR TITLE
Fixing autoscroll

### DIFF
--- a/BigBug/BigBug.csproj
+++ b/BigBug/BigBug.csproj
@@ -65,6 +65,15 @@
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CustomCommands>
+      <CustomCommands>
+        <Command>
+          <type>AfterBuild</type>
+          <command>packages\Doxygen.1.8.14\tools\doxygen.exe doxygen.conf doxygen.conf</command>
+          <workingdir>${SolutionDir}</workingdir>
+        </Command>
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Doxygen|x86'">
     <OutputPath>bin\x86\Doxygen\</OutputPath>
@@ -145,17 +154,4 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Doxygen (
- cd $(SolutionDir)
- packages\Doxygen.1.8.14\tools\doxygen.exe doxygen.conf doxygen.conf
-)</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/BigBug/MainForm.Designer.cs
+++ b/BigBug/MainForm.Designer.cs
@@ -49,6 +49,7 @@
             this.dataGrid = new System.Windows.Forms.DataGridView();
             this.labelClearFilter = new System.Windows.Forms.Label();
             this.browserOpenSingleFile = new System.Windows.Forms.OpenFileDialog();
+            this.checkAutoscroll = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.dataGrid)).BeginInit();
             this.SuspendLayout();
             // 
@@ -232,7 +233,15 @@
             this.labelClearFilter.Text = "X";
             this.labelClearFilter.Visible = false;
             this.labelClearFilter.Click += new System.EventHandler(this.labelClearFilter_Click);
-            // 
+            //
+            // checkAutoscroll
+            //
+            this.checkAutoscroll.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.checkAutoscroll.Text = "Autoscroll";
+            this.checkAutoscroll.Checked = true;
+            this.checkAutoscroll.Location = new System.Drawing.Point(200, 517);
+            this.checkAutoscroll.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.checkAutoscroll.Size = new System.Drawing.Size(120, 17);
             // browserOpenSingleFile
             // 
             this.browserOpenSingleFile.FileName = "browserOpenSingleFile";
@@ -247,6 +256,7 @@
             this.Controls.Add(this.labelFilter);
             this.Controls.Add(this.buttonNewSingleFileProject);
             this.Controls.Add(this.textFilter);
+            this.Controls.Add(this.checkAutoscroll);
             this.Controls.Add(this.labelAuthor);
             this.Controls.Add(this.labelProjectName);
             this.Controls.Add(this.buttonClear);
@@ -288,6 +298,7 @@
         private System.Windows.Forms.DataGridView dataGrid;
         private System.Windows.Forms.Label labelClearFilter;
         private System.Windows.Forms.OpenFileDialog browserOpenSingleFile;
+        private System.Windows.Forms.CheckBox checkAutoscroll;
     }
 }
 

--- a/BigBug/MainForm.cs
+++ b/BigBug/MainForm.cs
@@ -38,7 +38,6 @@ namespace BigBug
 {
     public partial class MainForm : Form
     {
-        Settings settings = new Settings("settings.ini"); ///< Settings wrapper to load or save settings.
         BBCodeBase bbCodeBase = new BBCodeBase(); ///< Database for all known (scanned) BBCode descriptors.
         DataTable dataTable = new DataTable(); ///< Table of received messages that is shown to the user.
         SerialReceiver serialComm; ///< Serial communication methods.
@@ -57,11 +56,9 @@ namespace BigBug
             SetVisuals(VisualStates.Default);
 
             // Restore Baud rate and MaxDataRows from the settings.
-            textBaud.Text = (settings.LoadSetting("General.Baud") != "") ? settings.LoadSetting("General.Baud") : "9600";
-            int maxDataRowsSetting = 0;
-            if (int.TryParse(settings.LoadSetting("User.MaxDataRows"), out maxDataRowsSetting))
-                maxDataRows = maxDataRowsSetting;
-            selectedPort = settings.LoadSetting("General.Port");
+            textBaud.Text = Properties.Settings.Default.Baud;
+            maxDataRows = Properties.Settings.Default.MaxDataRows;
+            selectedPort = Properties.Settings.Default.Port;
 
             // Initialize serial communicator in order to fill dataTable with received data.
             serialComm = new SerialReceiver(ref dataTable);
@@ -76,13 +73,13 @@ namespace BigBug
         private void buttonNewProject_Click(object sender, EventArgs e)
         {
             // Load Recent opened folder and set it to the folder browser initial path.
-            browserNewProject.SelectedPath = settings.LoadSetting("General.RecentProject");
+            browserNewProject.SelectedPath = Properties.Settings.Default.RecentProject;
 
             // Show browser.
             if (browserNewProject.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
                 // Get supported file extensions.
-                string supportedFileExtensionsString = (settings.LoadSetting("User.FileExtensions") != "") ? settings.LoadSetting("User.FileExtensions") : Properties.Resources.supportedFileExtensions;
+                string supportedFileExtensionsString = Properties.Settings.Default.FileExtensions;
                 string[] supportedFileExtensions = supportedFileExtensionsString.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
                 // Use ProjectScanner to scan all files.
@@ -98,7 +95,8 @@ namespace BigBug
                 SetVisuals(GetVisuals() | VisualStates.ProjectOpen);
 
                 // Save teh successfuly opened project path.
-                settings.SaveSetting("General.RecentProject", browserNewProject.SelectedPath);
+                Properties.Settings.Default.RecentProject = browserNewProject.SelectedPath;
+                Properties.Settings.Default.Save();
             }
         }
 
@@ -124,8 +122,9 @@ namespace BigBug
                 if ((comboPorts.SelectedItem != null) && serialComm.OpenPort(comboPorts.SelectedItem.ToString(), textBaud.Text, false, false))
                 {
                     // Save the successfull settings.
-                    settings.SaveSetting("General.Baud", textBaud.Text.ToString());
-                    settings.SaveSetting("General.Port", comboPorts.SelectedItem.ToString());
+                    Properties.Settings.Default.Baud = textBaud.Text.ToString();
+                    Properties.Settings.Default.Port = comboPorts.SelectedItem.ToString();
+                    Properties.Settings.Default.Save();
                     selectedPort = comboPorts.SelectedItem.ToString();
 
                     // Set SerialEnabled bit and update visuals.
@@ -221,7 +220,7 @@ namespace BigBug
         private void buttonSave_Click(object sender, EventArgs e)
         {
             saveFile.FileName = "";
-            saveFile.InitialDirectory = settings.LoadSetting("General.Save");
+            saveFile.InitialDirectory = Properties.Settings.Default.SaveDir;
 
             if ((saveFile.ShowDialog() == System.Windows.Forms.DialogResult.OK) && !timerSerialCommListener.Enabled)
             {
@@ -235,7 +234,8 @@ namespace BigBug
                 fs.Close();
 
                 //-- Save.
-                settings.SaveSetting("General.Save", Path.GetDirectoryName(saveFile.FileName));
+                Properties.Settings.Default.SaveDir = Path.GetDirectoryName(saveFile.FileName);
+                Properties.Settings.Default.Save();
             }
         }
 
@@ -247,7 +247,7 @@ namespace BigBug
         private void buttonNewSingleFileProject_Click(object sender, EventArgs e)
         {
             // Load Recent opened folder and set it to the folder browser initial path.
-            browserOpenSingleFile.FileName = settings.LoadSetting("General.RecentSingleFile");
+            browserOpenSingleFile.FileName = Properties.Settings.Default.RecentSingleFile;
 
             // Show browser.
             if (browserOpenSingleFile.ShowDialog() == System.Windows.Forms.DialogResult.OK)
@@ -265,7 +265,8 @@ namespace BigBug
                 SetVisuals(GetVisuals() | VisualStates.ProjectOpen);
 
                 // Save teh successfuly opened project path.
-                settings.SaveSetting("General.RecentSingleFile", browserOpenSingleFile.FileName);
+                Properties.Settings.Default.RecentSingleFile = browserOpenSingleFile.FileName;
+                Properties.Settings.Default.Save();
             }
         }
 

--- a/BigBug/MainForm.cs
+++ b/BigBug/MainForm.cs
@@ -185,9 +185,6 @@ namespace BigBug
          */
         private void serialCommListenerTimer_Tick(object sender, EventArgs e)
         {
-            // Unbind dataTable from dataGrid (improves performance).
-            dataGrid.DataSource = null;
-
             // Call serial data receiver.
             serialComm.GetSerialData(ref bbCodeBase, maxDataRows);
 

--- a/BigBug/Properties/Settings.Designer.cs
+++ b/BigBug/Properties/Settings.Designer.cs
@@ -22,5 +22,117 @@ namespace BigBug.Properties {
                 return defaultInstance;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("115200")]
+        public string Baud
+        {
+            get
+            {
+                return ((string)(this["Baud"]));
+            }
+
+            set
+            {
+                this["Baud"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("COM1")]
+        public string Port
+        {
+            get
+            {
+                return ((string)(this["Port"]));
+            }
+
+            set
+            {
+                this["Port"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("100000")]
+        public int MaxDataRows
+        {
+            get
+            {
+                return ((int)(this["MaxDataRows"]));
+            }
+
+            set
+            {
+                this["MaxDataRows"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string RecentProject
+        {
+            get
+            {
+                return ((string)(this["RecentProject"]));
+            }
+
+            set
+            {
+                this["RecentProject"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("c cpp hpp")]
+        public string FileExtensions
+        {
+            get
+            {
+                return ((string)(this["FileExtensions"]));
+            }
+
+            set
+            {
+                this["FileExtensions"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string SaveDir
+        {
+            get
+            {
+                return ((string)(this["SaveDir"]));
+            }
+
+            set
+            {
+                this["SaveDir"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string RecentSingleFile
+        {
+            get
+            {
+                return ((string)(this["RecentSingleFile"]));
+            }
+
+            set
+            {
+                this["RecentSingleFile"] = value;
+            }
+        }
     }
 }

--- a/BigBug/Properties/Settings.settings
+++ b/BigBug/Properties/Settings.settings
@@ -3,5 +3,27 @@
   <Profiles>
     <Profile Name="(Default)" />
   </Profiles>
+  <Settings>
+    <Setting Name="Baud" Type="System.String" Scope="User">
+        <Value> "9600" </Value>
+    </Setting>
+    <Setting Name="Port" Type="System.String" Scope="User">
+        <Value> "/dev/ttyUSB0" </Value>
+    </Setting>
+    <Setting Name="maxDataRows" Type="int" Scope="User">
+        <Value> 100000 </Value>
+    </Setting>
+    <Setting Name="RecentProject" Type="System.String" Scope="User">
+        <Value> "" </Value>
+    </Setting>
+    <Setting Name="FileExtensions" Type="System.String" Scope="User">
+        <Value> "c cpp hpp" </Value>
+    </Setting>
+    <Setting Name="SaveDir" Type="System.String" Scope="User">
+        <Value> "" </Value>
+    </Setting>
+    <Setting Name="RecentSingleFile" Type="System.String" Scope="User">
+        <Value> "" </Value>
+    </Setting>
   <Settings />
 </SettingsFile>

--- a/BigBug/Visuals.cs
+++ b/BigBug/Visuals.cs
@@ -40,6 +40,8 @@ namespace BigBug
             DataUpdate = 0x01 << 2,
         }
 
+        private int lastRowCount;
+
         private VisualStates visualState = VisualStates.Default;///< Keeps the up-to-date visual layout.
 
         /**
@@ -51,8 +53,10 @@ namespace BigBug
             // Data update.
             if ((state & VisualStates.DataUpdate) == VisualStates.DataUpdate)
             {
-                // Bind dataTable to dataGrid.
-                dataGrid.DataSource = dataTable;
+                if (lastRowCount == dataGrid.Rows.Count)
+                    return;
+
+                lastRowCount = dataGrid.Rows.Count;
 
                 // Set column properties, if columns are created.
                 if (dataGrid.Columns.Count == 2)
@@ -65,8 +69,11 @@ namespace BigBug
                         dataGrid.Columns[1].FillWeight = 10000;
 
                     // Scroll to the bottom of the view.
-                    if (dataGrid.Rows.Count > 0)
-                        dataGrid.FirstDisplayedScrollingRowIndex = dataGrid.Rows.Count - 1;
+                    if (dataGrid.Rows.Count > 0 && checkAutoscroll.Checked)
+                    {
+                        dataGrid.CurrentCell = dataGrid.Rows[dataGrid.RowCount - 1].Cells[0];
+                        dataGrid.ClearSelection();
+                    }
                 }
 
                 // Clear DataUpdate state bit.
@@ -88,6 +95,10 @@ namespace BigBug
 
                 // Change button name.
                 buttonPortOpenClose.Text = "&Port Close";
+
+
+                // Bind dataTable to dataGrid.
+                dataGrid.DataSource = dataTable;
             }
             else
             {


### PR DESCRIPTION
This patch fixes autoscroll in several ways:
    * Model should not be detached and reattached each time, it hurts
      performances and reset internal caching system from the view.
    * View should scrolled only when there are new datas in the queue:
      scrolling on each second hurts usability.
    * Scrolling should be a user choice: forcing the scrolling when a user
      is reading something important hurts usability. This patch adds a
      checkbox to choose if autoscroll to bottom or not